### PR TITLE
Fix off by one in OLC BTree deletion of child nodes

### DIFF
--- a/src/indices/olc_btree/thread/btree_olc.h
+++ b/src/indices/olc_btree/thread/btree_olc.h
@@ -207,7 +207,7 @@ template <class Key> struct BTreeInner : public BTreeInnerBase
 
     virtual ~BTreeInner()
     {
-        for (auto i = 0u; i < count; i++)
+        for (auto i = 0u; i <= count; i++)
         {
             if (children[i] != nullptr)
             {


### PR DESCRIPTION
Hello there!

We noticed a minor error in the deletion of OLC-BTrees leading to a memory leak.

The count of inner BTree nodes refers to the number of keys present, while the number of child pointers is 1 larger.
One child pointer is not deleted, which leaks memory if you create and delete multiple BTrees at runtime.

Best,
Fabian Mahling

